### PR TITLE
Remove reliance on FitbitAppCredentials in the FitbitClient.

### DIFF
--- a/Fitbit.Portable.Tests/FatTests.cs
+++ b/Fitbit.Portable.Tests/FatTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using NUnit.Framework;
 using AutoFixture;
 using System.Threading.Tasks;
+using AutoFixture.AutoMoq;
 using Fitbit.Api.Portable;
 using Fitbit.Models;
 
@@ -20,6 +21,7 @@ namespace Fitbit.Portable.Tests
         public void Init()
         {
             fixture = new Fixture();
+            fixture.Customize(new AutoMoqCustomization());
         }
 
         [Test]

--- a/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
+++ b/Fitbit.Portable.Tests/Fitbit.Portable.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.6.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.6.0" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />

--- a/Fitbit.Portable.Tests/FitbitClientConstructorTests.cs
+++ b/Fitbit.Portable.Tests/FitbitClientConstructorTests.cs
@@ -1,11 +1,6 @@
 ﻿using Fitbit.Api.Portable;
 using Fitbit.Api.Portable.OAuth2;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Net.Http;
 
 namespace Fitbit.Portable.Tests
@@ -17,10 +12,9 @@ namespace Fitbit.Portable.Tests
         [Category("constructor")]
         public void Most_Basic()
         {
-            var credentials = new FitbitAppCredentials() { ClientId = "SomeID", ClientSecret = "THE Secret ;)" };
             var accessToken = new OAuth2AccessToken() { Token = "", TokenType = "", ExpiresIn = 3600, RefreshToken = ""};
 
-            var sut = new FitbitClient(credentials, accessToken);
+            var sut = new FitbitClient(accessToken);
 
             Assert.IsNotNull(sut.HttpClient);
         }
@@ -38,11 +32,10 @@ namespace Fitbit.Portable.Tests
         [Category("constructor")]
         public void Can_Instantiate_Without_Any_Interceptors()
         {
-            var credentials = new FitbitAppCredentials() { ClientId = "SomeID", ClientSecret = "THE Secret ;)" };
             var accessToken = new OAuth2AccessToken() { Token = "", TokenType = "", ExpiresIn = 3600, RefreshToken = "" };
 
             //Ensure not even the auto-token-refresh interceptor is active
-            var sut = new FitbitClient(credentials, accessToken, false);
+            var sut = new FitbitClient(accessToken, enableOAuth2TokenRefresh: false);
 
             Assert.IsNotNull(sut.HttpClient);
         }
@@ -51,11 +44,10 @@ namespace Fitbit.Portable.Tests
         [Category("constructor")]
         public void Can_Use_Interceptors_Without_Autorefresh()
         {
-            var credentials = new FitbitAppCredentials() { ClientId = "SomeID", ClientSecret = "THE Secret ;)" };
             var accessToken = new OAuth2AccessToken() { Token = "", TokenType = "", ExpiresIn = 3600, RefreshToken = "" };
 
-            //Registere an interceptor, but disable the auto-token-refresh interceptor
-            var sut = new FitbitClient(credentials, accessToken, new InterceptorCounter(), false);
+            //Register an interceptor, but disable the auto-token-refresh interceptor
+            var sut = new FitbitClient(accessToken, new InterceptorCounter(), false);
 
             Assert.IsNotNull(sut.HttpClient);
         }

--- a/Fitbit.Portable.Tests/GoalsTests.cs
+++ b/Fitbit.Portable.Tests/GoalsTests.cs
@@ -6,6 +6,7 @@ using Fitbit.Api.Portable;
 using NUnit.Framework;
 using AutoFixture;
 using System.Threading.Tasks;
+using AutoFixture.AutoMoq;
 
 namespace Fitbit.Portable.Tests
 {
@@ -18,6 +19,7 @@ namespace Fitbit.Portable.Tests
         public void Init()
         {
             fixture = new Fixture();
+            fixture.Customize(new AutoMoqCustomization());
         }
 
         [Test] [Category("Portable")]

--- a/Fitbit.Portable.Tests/WeightTests.cs
+++ b/Fitbit.Portable.Tests/WeightTests.cs
@@ -8,6 +8,7 @@ using Fitbit.Models;
 using NUnit.Framework;
 using AutoFixture;
 using System.Threading.Tasks;
+using AutoFixture.AutoMoq;
 
 namespace Fitbit.Portable.Tests
 {
@@ -20,6 +21,7 @@ namespace Fitbit.Portable.Tests
         public void Init()
         {
             fixture = new Fixture();
+            fixture.Customize(new AutoMoqCustomization());
         }
 
         [Test]

--- a/Fitbit.Portable/Constants.cs
+++ b/Fitbit.Portable/Constants.cs
@@ -2,11 +2,13 @@
 {
     internal class Constants
     {
-        public const string BaseApiUrl = "https://api.fitbit.com/";
-        public const string TemporaryCredentialsRequestTokenUri = "oauth/request_token";
-        public const string TemporaryCredentialsAccessTokenUri = "oauth/access_token";
-        public const string AuthorizeUri = "oauth/authorize";
-        public const string LogoutAndAuthorizeUri = "oauth/logout_and_authorize";
+        public static string BaseApiUrl => "https://api.fitbit.com/";
+
+        /// <summary>
+        /// The fitbit api url for oAuth2 token request
+        /// </summary>
+        public static string OAuth2TokenUrl => $"{BaseApiUrl}oauth2/token";
+
         public const string FloorsUnsupportedOnDeviceError = "Invalid time series resource path: /activities/floors";
 
         public class Headers

--- a/Fitbit.Portable/FitbitClient.cs
+++ b/Fitbit.Portable/FitbitClient.cs
@@ -14,8 +14,6 @@ namespace Fitbit.Api.Portable
 {
     public class FitbitClient : IFitbitClient
     {
-        public FitbitAppCredentials AppCredentials { get; private set; }
-
         private OAuth2AccessToken _accesToken;
         public OAuth2AccessToken AccessToken
         {
@@ -28,7 +26,9 @@ namespace Fitbit.Api.Portable
                 _accesToken = value;
                 //If we update the AccessToken after HttpClient has been created, then reconfigure authorization header
                 if (HttpClient != null)
+                {
                     ConfigureAuthorizationHeader();
+                }
             }
         }
 
@@ -36,92 +36,66 @@ namespace Fitbit.Api.Portable
         /// The httpclient which will be used for the api calls through the FitbitClient instance
         /// </summary>
         public HttpClient HttpClient { get; private set; }
-
         public ITokenManager TokenManager { get; private set; }
         public bool OAuth2TokenAutoRefresh { get; set; }
-        public List<IFitbitInterceptor> FitbitInterceptorPipeline { get; private set; }
-
-
+        private List<IFitbitInterceptor> FitbitInterceptorPipeline { get; set; }
 
         /// <summary>
-        /// Simplest constructor for OAuth2- requires the minimum information required by FitBit.Net client to make succesful calls to Fitbit Api
+        /// Simple constructor for OAuth2- requires the minimum information required by FitBit.Net client to make succesful calls to Fitbit Api
         /// </summary>
-        /// <param name="credentials">Obtain this information from your developer dashboard. App credentials are required to perform token refresh</param>
         /// <param name="accessToken">Authenticate with Fitbit API using OAuth2. Authenticator2 class is a helper for this process</param>
         /// <param name="interceptor">An interface that enables sniffing all outgoing and incoming http requests from FitbitClient</param>
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, IFitbitInterceptor interceptor = null, bool enableOAuth2TokenRefresh = true, ITokenManager tokenManager = null)
+        /// <param name="enableOAuth2TokenRefresh"></param>
+        /// <param name="tokenManager">Implementation of ITokenManager which is required for the scope of the FitbitClient instance.</param>
+        public FitbitClient(OAuth2AccessToken accessToken, IFitbitInterceptor interceptor = null, bool enableOAuth2TokenRefresh = true, ITokenManager tokenManager = null)
         {
-            this.AppCredentials = credentials;
-            this.AccessToken = accessToken;
-
-            this.FitbitInterceptorPipeline = new List<IFitbitInterceptor>();
-
-
+            AccessToken = accessToken;
+            TokenManager = tokenManager;
+            FitbitInterceptorPipeline = new List<IFitbitInterceptor>();
+            
             if (interceptor != null)
             {
-                this.FitbitInterceptorPipeline.Add(interceptor);
+                FitbitInterceptorPipeline.Add(interceptor);
             }
-
-            ConfigureTokenManager(tokenManager);
 
             //Auto refresh should always be the last handle to be registered.
             ConfigureAutoRefresh(enableOAuth2TokenRefresh);
-
             CreateHttpClientForOAuth2();
         }
 
         private void ConfigureAutoRefresh(bool enableOAuth2TokenRefresh)
         {
-            this.OAuth2TokenAutoRefresh = enableOAuth2TokenRefresh;
+            OAuth2TokenAutoRefresh = enableOAuth2TokenRefresh;
             if (OAuth2TokenAutoRefresh)
-                this.FitbitInterceptorPipeline.Add(new OAuth2AutoRefreshInterceptor());
-            return;
+            {
+                FitbitInterceptorPipeline.Add(new OAuth2AutoRefreshInterceptor());
+            }
         }
 
         /// <summary>
-        /// Simplest constructor for OAuth2- requires the minimum information required by FitBit.Net client to make succesful calls to Fitbit Api
+        /// Simple constructor for OAuth2- requires the minimum information required by FitBit.Net client to make successful calls to Fitbit Api
         /// </summary>
-        /// <param name="credentials">Obtain this information from your developer dashboard. App credentials are required to perform token refresh</param>
         /// <param name="accessToken">Authenticate with Fitbit API using OAuth2. Authenticator2 class is a helper for this process</param>
-        /// <param name="interceptor">An interface that enables sniffing all outgoing and incoming http requests from FitbitClient</param>
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, List<IFitbitInterceptor> interceptors, bool enableOAuth2TokenRefresh = true, ITokenManager tokenManager = null)
+        /// <param name="interceptors">An interface that enables sniffing all outgoing and incoming http requests from FitbitClient</param>
+        /// <param name="enableOAuth2TokenRefresh"></param>
+        /// <param name="tokenManager">Implementation of ITokenManager which is required for the scope of the FitbitClient instance.</param>
+        public FitbitClient(OAuth2AccessToken accessToken, List<IFitbitInterceptor> interceptors, bool enableOAuth2TokenRefresh = true, ITokenManager tokenManager = null)
         {
-            this.AppCredentials = credentials;
-            this.AccessToken = accessToken;
+            AccessToken = accessToken;
+            TokenManager = tokenManager;
 
-            this.FitbitInterceptorPipeline = new List<IFitbitInterceptor>();
+            FitbitInterceptorPipeline = new List<IFitbitInterceptor>();
 
-            if (interceptors != null && interceptors.Count > 0)
-                this.FitbitInterceptorPipeline.AddRange(interceptors);
-
-            ConfigureTokenManager(tokenManager);
+            if (interceptors?.Count > 0)
+            {
+                FitbitInterceptorPipeline.AddRange(interceptors);
+            }
 
             //Auto refresh should always be the last handle to be registered.
             ConfigureAutoRefresh(enableOAuth2TokenRefresh);
             CreateHttpClientForOAuth2();
         }
-
-
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, bool enableOAuth2TokenRefresh) : this(credentials, accessToken, null, enableOAuth2TokenRefresh)
-        {
-
-        }
-
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, List<IFitbitInterceptor> interceptors, bool enableOAuth2TokenRefresh) : this(credentials, accessToken, interceptors, enableOAuth2TokenRefresh, null)
-        {
-
-        }
-
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, List<IFitbitInterceptor> interceptors, ITokenManager tokenManager) : this(credentials, accessToken, interceptors, true, tokenManager)
-        {
-
-        }
-
-        public FitbitClient(FitbitAppCredentials credentials, OAuth2AccessToken accessToken, IFitbitInterceptor interceptor, ITokenManager tokenManager) : this(credentials, accessToken, interceptor, true, tokenManager)
-        {
-
-        }
-
+        
         /// <summary>
         /// Advanced mode for library usage. Allows custom creation of HttpClient to account for future authentication methods
         /// </summary>
@@ -129,15 +103,8 @@ namespace Fitbit.Api.Portable
         /// <param name="interceptor">An interface that enables sniffing all outgoing and incoming http requests from FitbitClient</param>
         public FitbitClient(Func<HttpMessageHandler, HttpClient> customFactory, IFitbitInterceptor interceptor = null, ITokenManager tokenManager = null)
         {
-            this.OAuth2TokenAutoRefresh = false;
-
-            ConfigureTokenManager(tokenManager);
-            this.HttpClient = customFactory(new FitbitHttpMessageHandler(this, interceptor));
-        }
-
-        private void ConfigureTokenManager(ITokenManager tokenManager)
-        {
-            TokenManager = tokenManager ?? new DefaultTokenManager();
+            TokenManager = tokenManager;
+            HttpClient = customFactory(new FitbitHttpMessageHandler(this, interceptor));
         }
 
         private void CreateHttpClientForOAuth2()

--- a/Fitbit.Portable/OAuth2/DefaultTokenManager.cs
+++ b/Fitbit.Portable/OAuth2/DefaultTokenManager.cs
@@ -1,16 +1,21 @@
-﻿namespace Fitbit.Api.Portable.OAuth2
-{
-    using System.Collections.Generic;
-    using System.Net.Http;
-    using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
 
-    internal class DefaultTokenManager : ITokenManager
+namespace Fitbit.Api.Portable.OAuth2
+{
+    public class DefaultTokenManager : ITokenManager
     {
-        private static string FitbitOauthPostUrl => "https://api.fitbit.com/oauth2/token";
+        private readonly FitbitAppCredentials _credentials;
+
+        public DefaultTokenManager(FitbitAppCredentials credentials)
+        {
+            _credentials = credentials;
+        }
 
         public async Task<OAuth2AccessToken> RefreshTokenAsync(FitbitClient client)
         {
-            string postUrl = FitbitOauthPostUrl;
+            string postUrl = Constants.OAuth2TokenUrl;
 
             var content = new FormUrlEncodedContent(new[]
             {
@@ -28,7 +33,7 @@
                 httpClient = client.HttpClient;
             }
 
-            var clientIdConcatSecret = OAuth2Helper.Base64Encode(client.AppCredentials.ClientId + ":" + client.AppCredentials.ClientSecret);
+            var clientIdConcatSecret = OAuth2Helper.Base64Encode(_credentials.ClientId + ":" + _credentials.ClientSecret);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", clientIdConcatSecret);
 
             HttpResponseMessage response = await httpClient.PostAsync(postUrl, content);

--- a/Fitbit.Portable/OAuth2/OAuth2Helper.cs
+++ b/Fitbit.Portable/OAuth2/OAuth2Helper.cs
@@ -10,8 +10,6 @@ namespace Fitbit.Api.Portable.OAuth2
     public class OAuth2Helper
     {
         private const string FitbitWebAuthBaseUrl = "https://www.fitbit.com";
-        private const string FitbitApiBaseUrl = "https://api.fitbit.com";
-
         private const string OAuthBase = "/oauth2";
 
         private string ClientId;
@@ -25,6 +23,7 @@ namespace Fitbit.Api.Portable.OAuth2
             this.ClientSecret = credentials.ClientSecret;
             this.RedirectUri = redirectUri;
         }
+
         public string GenerateAuthUrl(string[] scopeTypes, string state = null)
         {
             var sb = new StringBuilder();
@@ -47,7 +46,7 @@ namespace Fitbit.Api.Portable.OAuth2
         {
             HttpClient httpClient = new HttpClient();
 
-            string postUrl = OAuth2Helper.FitbitOauthPostUrl;
+            string postUrl = Constants.OAuth2TokenUrl;
 
             var content = new FormUrlEncodedContent(new[]
             {
@@ -70,9 +69,6 @@ namespace Fitbit.Api.Portable.OAuth2
 
             return accessToken;
         }
-
-        public static readonly string FitbitOauthPostUrl = "https://api.fitbit.com/oauth2/token";
-
 
         public static OAuth2AccessToken ParseAccessTokenResponse(string responseString)
         {

--- a/SampleConsole/SampleConsole/App.config
+++ b/SampleConsole/SampleConsole/App.config
@@ -4,7 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
     <appSettings>
-      <add key="FitbitConsumerKey" value="CLIENT-ID"/>
-      <add key="FitbitConsumerSecret" value="CLIENT-SECRET-HERE"/>
+      <add key="FitbitClientId" value="CLIENT-ID"/>
+      <add key="FitbitClientSecret" value="CLIENT-SECRET-HERE"/>
     </appSettings>
 </configuration>

--- a/SampleConsole/SampleConsole/AuthorizationHelper.cs
+++ b/SampleConsole/SampleConsole/AuthorizationHelper.cs
@@ -20,7 +20,9 @@ namespace SampleConsole
             // try to retrieve the token from disk
             OAuth2AccessToken token = GetAccessTokenAsync(scopes).Result;
 
-            return new FitbitClient(new FitbitAppCredentials() { ClientId = Options.ClientId, ClientSecret = Options.ClientSecret }, token, true);
+            var tokenManager = new DefaultTokenManager(new FitbitAppCredentials { ClientId = Options.ClientId, ClientSecret = Options.ClientSecret });
+
+            return new FitbitClient(token, tokenManager: tokenManager);
         }
 
         public static async Task<OAuth2AccessToken> GetAccessTokenAsync(params string[] scopes)
@@ -79,6 +81,7 @@ namespace SampleConsole
         {
             Colorizer.WriteLine("Sending authorization request...");
             string scope = string.Join("%20", scopes);
+            
             string authorizeUrl = $"https://www.fitbit.com/oauth2/authorize?response_type=code&client_id={Options.ClientId}&scope={scope}&expires_in=86400";
             Process.Start(authorizeUrl);
 

--- a/SampleConsole/SampleConsole/Options.cs
+++ b/SampleConsole/SampleConsole/Options.cs
@@ -8,8 +8,8 @@ namespace SampleConsole
 {
     public class Options
     {
-        public static string ClientId = System.Configuration.ConfigurationManager.AppSettings["FitbitConsumerKey"];
-        public static string ClientSecret = System.Configuration.ConfigurationManager.AppSettings["FitbitConsumerSecret"];
-        public static string[] AllScopes = new string[] { "activity ", "nutrition ", "heartrate ", "location ", "nutrition ", "profile ", "settings ", "sleep ", "social ", "weight" };
+        public static string ClientId = System.Configuration.ConfigurationManager.AppSettings["FitbitClientId"];
+        public static string ClientSecret = System.Configuration.ConfigurationManager.AppSettings["FitbitClientSecret"];
+        public static string[] AllScopes = new string[] { "activity", "nutrition", "heartrate", "location", "nutrition", "profile", "settings", "sleep", "social", "weight" };
     }
 }

--- a/SampleConsole/SampleConsole/SampleConsole.csproj
+++ b/SampleConsole/SampleConsole/SampleConsole.csproj
@@ -57,7 +57,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/SampleWebApplication/SampleWebApplication/Controllers/FitbitController.cs
+++ b/SampleWebApplication/SampleWebApplication/Controllers/FitbitController.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Web.Mvc;
-using Fitbit.Api;
 using System.Configuration;
 using Fitbit.Models;
 using Fitbit.Api.Portable;
@@ -12,7 +10,7 @@ namespace SampleWebMVC.Controllers
 {
     public class FitbitController : Controller
     {
-        public static string[] AllScopes = new string[] { "activity ", "nutrition ", "heartrate ", "location ", "nutrition ", "profile ", "settings ", "sleep ", "social ", "weight" };
+        public static string[] AllScopes = new string[] { "activity", "nutrition", "heartrate", "location", "nutrition", "profile", "settings", "sleep", "social", "weight" };
 
         public ActionResult Index()
         {
@@ -219,7 +217,8 @@ namespace SampleWebMVC.Controllers
                 if (accessToken != null)
                 {
                     var appCredentials = (FitbitAppCredentials)Session["AppCredentials"];
-                    FitbitClient client = new FitbitClient(appCredentials, accessToken);
+                    var tokenManager = new DefaultTokenManager(appCredentials);
+                    FitbitClient client = new FitbitClient(accessToken, tokenManager: tokenManager);
                     Session["FitbitClient"] = client;
                     return client;
                 }


### PR DESCRIPTION
It's only used by the DefaultTokenManager so moved it to it's constructor.

Nothing should require a dependency if only being used by something else!

Removed the unrequired constructor overloads which were originally to aid upgrading from v1 to v2. With optional parameters these are no longer required.